### PR TITLE
Don't wait for Nextjs page to compile

### DIFF
--- a/sandbox-templates/nextjs-developer/compile_page.sh
+++ b/sandbox-templates/nextjs-developer/compile_page.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs during building the sandbox template
+# and makes sure the Next.js app is (1) running and (2) the `/` page is compiled
+
+function ping_server() {
+	counter=0
+	response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000")
+	while [[ ${response} -ne 200 ]]; do
+	  let counter++
+	  if  (( counter % 20 == 0 )); then
+        echo "Waiting for server to start..."
+        sleep 0.1
+      fi
+
+	  response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000")
+	done
+}
+
+ping_server &
+cd /home/user && npx next

--- a/sandbox-templates/nextjs-developer/e2b.Dockerfile
+++ b/sandbox-templates/nextjs-developer/e2b.Dockerfile
@@ -10,11 +10,14 @@ RUN apt-get update && apt-get install -y curl nano \
 RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
     apt-get install -y nodejs
 
+COPY compile_page.sh /home/user/compile_page.sh
+
 # Install dependencies and customize sandbox
 WORKDIR /home/user/nextjs-app
 
 RUN npx create-next-app@latest . --ts --tailwind --no-eslint --import-alias "@/*" --use-npm --app --no-src-dir
-RUN npm i -g vercel
+# Here you can install NPM dependencies to the Nextjs app
 RUN npm install recharts
 
+# Move the Nextjs app to the home directory and remove the nextjs-app directory
 RUN mv /home/user/nextjs-app/* /home/user/ && rm -rf /home/user/nextjs-app

--- a/sandbox-templates/nextjs-developer/e2b.toml
+++ b/sandbox-templates/nextjs-developer/e2b.toml
@@ -9,9 +9,9 @@
 # import { Sandbox } from 'e2b'
 # const sandbox = await Sandbox.create({ template: 'nextjs-developer' })
 
-template_id = "scwxnhs1apt5uj7na7db"
+memory_mb = 4_096
+cpu_count = 4
+start_cmd = "/home/user/compile_page.sh"
 dockerfile = "e2b.Dockerfile"
 template_name = "nextjs-developer"
-start_cmd = "/home/user/compile_page.sh"
-cpu_count = 4
-memory_mb = 4_096
+template_id = "scwxnhs1apt5uj7na7db"

--- a/sandbox-templates/nextjs-developer/e2b.toml
+++ b/sandbox-templates/nextjs-developer/e2b.toml
@@ -12,6 +12,6 @@
 template_id = "scwxnhs1apt5uj7na7db"
 dockerfile = "e2b.Dockerfile"
 template_name = "nextjs-developer"
-start_cmd = "cd /home/user && npx next"
+start_cmd = "/home/user/compile_page.sh"
 cpu_count = 4
 memory_mb = 4_096


### PR DESCRIPTION
This PR pre-compiles the `/` page of a nextjs app for the nextjs developer case. Waiting time for user to see the rendered `/` page should be almost instant