### PR TITLE
fix(ollama): correct Ollama baseURL

### DIFF
--- a/lib/models.ts
+++ b/lib/models.ts
@@ -34,7 +34,7 @@ export function getModelClient(model: LLMModel, config: LLMModelConfig) {
     mistral: () => createMistral({ apiKey })(modelNameString),
     groq: () => createOpenAI({ apiKey: apiKey || process.env.GROQ_API_KEY, baseURL: 'https://api.groq.com/openai/v1' })(modelNameString),
     togetherai: () => createOpenAI({ apiKey: apiKey || process.env.TOGETHER_AI_API_KEY, baseURL: 'https://api.together.xyz/v1' })(modelNameString),
-    ollama: () => createOllama()(modelNameString),
+    ollama: () => createOllama({ baseURL: process.env.OLLAMA_HOST + '/api' || 'http://127.0.0.1:11434/api' })(modelNameString),
   }
 
   const createClient = providerConfigs[providerId as keyof typeof providerConfigs]


### PR DESCRIPTION
This PR fixes the Ollama baseURL to add the missing /api path, it will also try to lookup the host from $OLLAMA_HOST which is a standard variable for Ollama clients.