### PR TITLE
Fix transparent background issue on Safari

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 @layer base {
   :root {
     /* --background: 32 100% 95%; */
-    --background: 0 0 100%;
+    --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;


### PR DESCRIPTION
Fix for transparent background issue on MacOS - Safari

- Updated the CSS variable `--background` to use the correct HSL format.
- Replaced the invalid value `0 0 100%` to `0 0% 100%` 
- Fixes the input text box and the Auth-Login Dialog box 

Example - 
before
<img width="932" alt="Text input on Safari" src="https://github.com/user-attachments/assets/49765113-81de-4903-a2b8-a3be50f31d82">

Post fix 
<img width="744" alt="Post Fix of the HSL values" src="https://github.com/user-attachments/assets/cf85bef1-2c3b-47c3-ac17-627253f2ed82">

