### PR TITLE
Add OpenRouter Anthropic model and update model list

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,5 @@
 E2B_API_KEY=
 # Get your Anthropic API key here https://console.anthropic.com
 ANTHROPIC_API_KEY=
+# Get your OpenRouter API key here https://openrouter.ai/keys
+OPENROUTER_API_KEY=

--- a/.env.template
+++ b/.env.template
@@ -2,5 +2,17 @@
 E2B_API_KEY=
 # Get your Anthropic API key here https://console.anthropic.com
 ANTHROPIC_API_KEY=
+# Get your OpenAI API key here https://platform.openai.com/account/api-keys
+OPENAI_API_KEY=
+# Get your Google API key here https://makersuite.google.com/app/apikey
+GOOGLE_API_KEY=
+# Get your Mistral API key here https://console.mistral.ai/api-keys/
+MISTRAL_API_KEY=
+# Get your Groq API key here https://console.groq.com/keys
+GROQ_API_KEY=
+# Get your Together AI API key here https://api.together.xyz/settings/api-keys
+TOGETHER_AI_API_KEY=
+# Get your Fireworks API key here https://app.fireworks.ai/users/settings/api-keys
+FIREWORKS_API_KEY=
 # Get your OpenRouter API key here https://openrouter.ai/keys
 OPENROUTER_API_KEY=

--- a/lib/models.json
+++ b/lib/models.json
@@ -97,8 +97,8 @@
       "name": "Mistral Large"
     },
     {
-      "id": "anthropic/claude-3-opus-20240229",
-      "name": "Claude 3 Opus (via OpenRouter)",
+      "id": "anthropic/claude-3.5-sonnet",
+      "name": "Claude 3.5 Sonnet (via OpenRouter)",
       "provider": "OpenRouter",
       "providerId": "openrouter"
     }

--- a/lib/models.json
+++ b/lib/models.json
@@ -95,6 +95,12 @@
       "provider": "Ollama",
       "providerId": "ollama",
       "name": "Mistral Large"
+    },
+    {
+      "id": "anthropic/claude-3-opus-20240229",
+      "name": "Claude 3 Opus (via OpenRouter)",
+      "provider": "OpenRouter",
+      "providerId": "openrouter"
     }
   ]
 }

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -36,6 +36,7 @@ export function getModelClient(model: LLMModel, config: LLMModelConfig) {
     togetherai: () => createOpenAI({ apiKey: apiKey || process.env.TOGETHER_AI_API_KEY, baseURL: baseURL || 'https://api.together.xyz/v1' })(modelNameString),
     ollama: () => createOllama({ baseURL })(modelNameString),
     fireworks: () => createOpenAI({ apiKey: apiKey || process.env.FIREWORKS_API_KEY, baseURL: baseURL || 'https://api.fireworks.ai/inference/v1' })(modelNameString),
+    openrouter: () => createOpenAI({ apiKey: apiKey || process.env.OPENROUTER_API_KEY, baseURL: baseURL || 'https://openrouter.ai/api/v1' })(modelNameString),
   }
 
   const createClient = providerConfigs[providerId as keyof typeof providerConfigs]
@@ -50,8 +51,8 @@ export function getModelClient(model: LLMModel, config: LLMModelConfig) {
 export function getDefaultMode (model: LLMModel) {
   const { id: modelNameString, providerId } = model
 
-  // monkey patch fireworks
-  if (providerId === 'fireworks') {
+  // monkey patch fireworks and openrouter
+  if (providerId === 'fireworks' || providerId === 'openrouter') {
     return 'json'
   }
 


### PR DESCRIPTION
# Add OpenRouter Anthropic model and update model list

 ## Changes

 1. Added OpenRouter as a new provider in `lib/models.ts`
 2. Updated `lib/models.json` to include Claude 3.5 Sonnet via OpenRouter
 3. Modified `getDefaultMode` function to use 'json' mode for OpenRouter

 ## Details

 ### New OpenRouter Provider

 - Added OpenRouter to the `providerConfigs` in `lib/models.ts`
 - Uses the OpenAI-compatible API endpoint for OpenRouter
 - Configurable with `OPENROUTER_API_KEY` environment variable

 ### New Model: Claude 3.5 Sonnet via OpenRouter

 - Added "anthropic/claude-3.5-sonnet" to the models list in `lib/models.json`
 - Provides access to Anthropic's Claude 3.5 Sonnet model through OpenRouter

 ### Default Mode Update

 - Updated `getDefaultMode` function to return 'json' for OpenRouter, similar to Fireworks

 ## Testing

 - Ensure the OpenRouter API key is set in the environment variables
 - Test creating a client for the new OpenRouter model
 - Verify that the model appears in the UI and can be selected
 - Test interactions with the Claude 3.5 Sonnet model via OpenRouter

 ## Notes

 - OpenRouter logo should be added to `public/thirdparty/logos/` if not already present
 - Update documentation to include information about the new OpenRouter integration and how to obtain and set up an API
 key